### PR TITLE
removed `from mezzanine.core.views import direct_to_template`

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -1,8 +1,5 @@
-
 from django.conf.urls import patterns, include, url
 from django.contrib import admin
-
-from mezzanine.core.views import direct_to_template
 
 
 admin.autodiscover()


### PR DESCRIPTION
removed `from mezzanine.core.views import direct_to_template` because it was not being used anywhere.
