### PR TITLE
Configurable profile model

### DIFF
--- a/drum/links/models.py
+++ b/drum/links/models.py
@@ -18,6 +18,7 @@ from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from mezzanine.accounts import get_profile_model
 from mezzanine.core.models import Displayable, Ownable
 from mezzanine.core.request import current_request
 from mezzanine.generic.models import Rating, Keyword, AssignedKeyword
@@ -88,5 +89,5 @@ def karma(sender, **kwargs):
         value *= 2
     content_object = rating.content_object
     if rating.user != content_object.user:
-        queryset = Profile.objects.filter(user=content_object.user)
+        queryset = get_profile_model().objects.filter(user=content_object.user)
         queryset.update(karma=models.F("karma") + value)

--- a/drum/links/templates/accounts/account_profile.html
+++ b/drum/links/templates/accounts/account_profile.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
-{% load i18n future mezzanine_tags %}
+{% load i18n future mezzanine_tags drum_tags %}
 
 {% block meta_title %}{{ profile_user.username }}{% endblock %}
-{% block title %}{{ profile_user.profile }}{% endblock %}
+{% block title %}{% get_profile profile_user %}{% endblock %}
 {% block body_id %}account{% endblock %}
 
 {% block main %}
@@ -13,7 +13,7 @@
 {% endif %}
 <div class="clearfix">
 
-    {% with profile_user.profile as profile %}
+    {% with get_profile profile_user as profile %}
     {% if profile.bio %}
     <p class="bio">{{ profile.bio|urlize|linebreaks }}</p>
     {% endif %}

--- a/drum/links/templates/accounts/account_profile.html
+++ b/drum/links/templates/accounts/account_profile.html
@@ -2,7 +2,7 @@
 {% load i18n future mezzanine_tags drum_tags %}
 
 {% block meta_title %}{{ profile_user.username }}{% endblock %}
-{% block title %}{% get_profile profile_user %}{% endblock %}
+{% block title %}{{ profile_user|profile_for }}{% endblock %}
 {% block body_id %}account{% endblock %}
 
 {% block main %}
@@ -13,7 +13,7 @@
 {% endif %}
 <div class="clearfix">
 
-    {% with get_profile profile_user as profile %}
+    {% with profile_user|profile_for as profile %}
     {% if profile.bio %}
     <p class="bio">{{ profile.bio|urlize|linebreaks }}</p>
     {% endif %}

--- a/drum/links/templates/accounts/includes/user_panel_nav.html
+++ b/drum/links/templates/accounts/includes/user_panel_nav.html
@@ -1,4 +1,4 @@
-{% load i18n future mezzanine_tags %}
+{% load i18n future mezzanine_tags drum_tags %}
 
 <ul class="nav pull-right"><li class="divider-vertical"></li></ul>
 
@@ -18,7 +18,7 @@
 <ul class="nav pull-right">
     {% url "profile" request.user.username as profile_url %}
     {% if not profile_url %}{% url "profile_update" as profile_url %}{% endif %}
-    <li><a href="{{ profile_url }}">{{ request.user.profile }}</a></li>
+    <li><a href="{{ profile_url }}">{% get_profile request.user %}</a></li>
 </ul>
 {% endif %}
 

--- a/drum/links/templates/accounts/includes/user_panel_nav.html
+++ b/drum/links/templates/accounts/includes/user_panel_nav.html
@@ -18,7 +18,7 @@
 <ul class="nav pull-right">
     {% url "profile" request.user.username as profile_url %}
     {% if not profile_url %}{% url "profile_update" as profile_url %}{% endif %}
-    <li><a href="{{ profile_url }}">{% get_profile request.user %}</a></li>
+    <li><a href="{{ profile_url }}">{{ request.user|profile_for }}</a></li>
 </ul>
 {% endif %}
 

--- a/drum/links/templates/generic/includes/comment.html
+++ b/drum/links/templates/generic/includes/comment.html
@@ -6,7 +6,7 @@
     {% if not comment.is_removed and comment.is_public %}
 
         <p class="comment-meta">
-            <a href="{% url "profile" comment.user.username %}">{% get_profile comment.user %}</a>
+            <a href="{% url "profile" comment.user.username %}">{{ comment.user|profile_for }}</a>
             {{ comment.submit_date|short_timesince }} ago
         </p>
         <p class="comment-comment">{{ comment.comment|comment_filter }}</p>

--- a/drum/links/templates/generic/includes/comment.html
+++ b/drum/links/templates/generic/includes/comment.html
@@ -6,7 +6,7 @@
     {% if not comment.is_removed and comment.is_public %}
 
         <p class="comment-meta">
-            <a href="{% url "profile" comment.user.username %}">{{ comment.user.profile }}</a>
+            <a href="{% url "profile" comment.user.username %}">{% get_profile comment.user %}</a>
             {{ comment.submit_date|short_timesince }} ago
         </p>
         <p class="comment-comment">{{ comment.comment|comment_filter }}</p>

--- a/drum/links/templates/generic/threadedcomment_list.html
+++ b/drum/links/templates/generic/threadedcomment_list.html
@@ -10,7 +10,7 @@
 {% for comment in object_list %}
 <div class="comment-item">
     <p class="comment">{{ comment.comment }}</p>
-    by <a href="{% url "profile" comment.user.username %}">{{ comment.user.profile }}</a>
+    by <a href="{% url "profile" comment.user.username %}">{% get_profile comment.user %}</a>
     {{ comment.submit_date|short_timesince }} ago in
     <a class="comments" href="{{ comment.get_absolute_url }}">{{ comment.content_object }}</a>
     <br clear="left">

--- a/drum/links/templates/generic/threadedcomment_list.html
+++ b/drum/links/templates/generic/threadedcomment_list.html
@@ -10,7 +10,7 @@
 {% for comment in object_list %}
 <div class="comment-item">
     <p class="comment">{{ comment.comment }}</p>
-    by <a href="{% url "profile" comment.user.username %}">{% get_profile comment.user %}</a>
+    by <a href="{% url "profile" comment.user.username %}">{{ comment.user|profile_for }}</a>
     {{ comment.submit_date|short_timesince }} ago in
     <a class="comments" href="{{ comment.get_absolute_url }}">{{ comment.content_object }}</a>
     <br clear="left">

--- a/drum/links/templates/links/link_detail.html
+++ b/drum/links/templates/links/link_detail.html
@@ -14,7 +14,7 @@
     <p class="description">{{ object.description }}</p>
     <div class="link-meta">
         {% rating_for object %}
-        by <a href="{% url "profile" object.user.username %}">{{ object.user.profile }}</a>
+        by <a href="{% url "profile" object.user.username %}">{% get_profile object.user %}</a>
         {{ object.publish_date|short_timesince }} ago
         {% keywords_for link as tags %}
         {% for tag in tags %}

--- a/drum/links/templates/links/link_detail.html
+++ b/drum/links/templates/links/link_detail.html
@@ -14,7 +14,7 @@
     <p class="description">{{ object.description }}</p>
     <div class="link-meta">
         {% rating_for object %}
-        by <a href="{% url "profile" object.user.username %}">{% get_profile object.user %}</a>
+        by <a href="{% url "profile" object.user.username %}">{{ object.user|profile_for }}</a>
         {{ object.publish_date|short_timesince }} ago
         {% keywords_for link as tags %}
         {% for tag in tags %}

--- a/drum/links/templates/links/link_list.html
+++ b/drum/links/templates/links/link_list.html
@@ -15,7 +15,7 @@
             <a href="{{ link.url }}">{{ link.title }}</a>
             <span class="domain">({{ link.domain }})</span>
         </h2>
-        by <a class="profile" href="{% url "profile" link.user.username %}">{{ link.user.profile }}</a>
+        by <a class="profile" href="{% url "profile" link.user.username %}">{% get_profile link.user %}</a>
         {{ link.publish_date|short_timesince }} ago |
         {% keywords_for link as tags %}
         {% for tag in tags %}

--- a/drum/links/templates/links/link_list.html
+++ b/drum/links/templates/links/link_list.html
@@ -15,7 +15,7 @@
             <a href="{{ link.url }}">{{ link.title }}</a>
             <span class="domain">({{ link.domain }})</span>
         </h2>
-        by <a class="profile" href="{% url "profile" link.user.username %}">{% get_profile link.user %}</a>
+        by <a class="profile" href="{% url "profile" link.user.username %}">{{ link.user|profile_for }}</a>
         {{ link.publish_date|short_timesince }} ago |
         {% keywords_for link as tags %}
         {% for tag in tags %}

--- a/drum/links/templatetags/drum_tags.py
+++ b/drum/links/templatetags/drum_tags.py
@@ -11,8 +11,8 @@ from drum.links.views import CommentList, USER_PROFILE_RELATED_NAME
 register = template.Library()
 
 
-@register.simple_tag(takes_context=True)
-def get_profile(context, user):
+@register.filter
+def profile_for(user):
     """
     Returns the profile object associated with the given user.
     """

--- a/drum/links/templatetags/drum_tags.py
+++ b/drum/links/templatetags/drum_tags.py
@@ -12,6 +12,14 @@ register = template.Library()
 
 
 @register.simple_tag(takes_context=True)
+def get_profile(context, user):
+    """
+    Returns the profile object associated with the given user.
+    """
+    return getattr(user, USER_PROFILE_RELATED_NAME)
+
+
+@register.simple_tag(takes_context=True)
 def order_comments_by_score_for(context, link):
     """
     Preloads threaded comments in the same way Mezzanine initially does,

--- a/drum/links/templatetags/drum_tags.py
+++ b/drum/links/templatetags/drum_tags.py
@@ -5,7 +5,7 @@ from django import template
 from django.template.defaultfilters import timesince
 
 from drum.links.utils import order_by_score
-from drum.links.views import CommentList
+from drum.links.views import CommentList, USER_PROFILE_RELATED_NAME
 
 
 register = template.Library()
@@ -18,7 +18,10 @@ def order_comments_by_score_for(context, link):
     but here we order them by score.
     """
     comments = defaultdict(list)
-    qs = link.comments.visible().select_related("user", "user__profile")
+    qs = link.comments.visible().select_related(
+        "user",
+        "user__%s" % (USER_PROFILE_RELATED_NAME)
+    )
     for comment in order_by_score(qs, CommentList.score_fields, "submit_date"):
         comments[comment.replied_to_id].append(comment)
     context["all_comments"] = comments


### PR DESCRIPTION
This pull request is for changes proposed in https://github.com/stephenmcd/drum/issues/15.

In `karma()` we now use `mezzanine.accounts.get_profile_model()`. The views have several instances of reverse access to the profile via the `User` model as part of queries. The moduIe is now determining the appropriate `related_name` and using that instead of "profile" in those cases. There are various cases of profile access in the template files. Since `get_profile()` doesn't exist in Django 1.7, a new method is defined to retrieve the appropriate profile for a given user object. The method is accessed in the form of a filter within the templates. The new syntax is hopefully still pretty readable. Of course custom implementations may well override those templates and may not need to use the filter approach at all. Updating the templates this way however should ensure that this still works out-of-the-box. 