### PR TITLE
In python3, reduce has been moved to the functools package.

### DIFF
--- a/drum/links/models.py
+++ b/drum/links/models.py
@@ -5,6 +5,7 @@ from future.builtins import int
 from re import sub, split
 from time import time
 from operator import ior
+from functools import reduce
 
 try:
     from urllib.parse import urlparse


### PR DESCRIPTION
This caused an error when posting a link in the admin site.
I think this will work in python2 also.