### PR TITLE
urls.py update for new Django format

### DIFF
--- a/drum/links/urls.py
+++ b/drum/links/urls.py
@@ -1,12 +1,12 @@
 from __future__ import unicode_literals
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.contrib.auth.decorators import login_required
 
 from drum.links.views import LinkList, LinkCreate, LinkDetail, CommentList, TagList
 
 
-urlpatterns = patterns("",
+urlpatterns = [
     url("^$",
         LinkList.as_view(),
         name="home"),
@@ -37,4 +37,4 @@ urlpatterns = patterns("",
     url("^tags/(?P<tag>.*)/$",
         LinkList.as_view(),
         name="link_list_tag"),
-)
+]

--- a/drum/project_template/project_name/urls.py
+++ b/drum/project_template/project_name/urls.py
@@ -1,16 +1,18 @@
 from __future__ import unicode_literals
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.contrib import admin
 
 
 admin.autodiscover()
 
 
-urlpatterns = patterns("",
-    ("^admin/", include(admin.site.urls)),
-    ("^", include("drum.links.urls")),
-    ("^", include("mezzanine.urls")),
-)
+urlpatterns = [
+    url("^admin/", include(admin.site.urls)),
+    url("^", include("drum.links.urls")),
+    url("^", include("mezzanine.urls")),
+]
 
-# Adds ``STATIC_URL`` to the context.
+# Adds ``STATIC_URL`` to the context of error pages, so that error
+# pages can use JS, CSS and images.
+handler404 = "mezzanine.core.views.page_not_found"
 handler500 = "mezzanine.core.views.server_error"


### PR DESCRIPTION
Update urls.py to support new `urlpatterns` format.
Copy code from Mezzanine to make sure it's align to it.