### PR TITLE
Uncomment all mezzanine.* apps in INSTALLED_APPS

### DIFF
--- a/drum/project_template/project_name/settings.py
+++ b/drum/project_template/project_name/settings.py
@@ -243,12 +243,12 @@ INSTALLED_APPS = (
     "mezzanine.core",
     "mezzanine.generic",
     "mezzanine.accounts",
-    #"mezzanine.blog",
-    #"mezzanine.forms",
-    #"mezzanine.pages",
-    #"mezzanine.galleries",
-    #"mezzanine.twitter",
-    #"mezzanine.mobile",
+    "mezzanine.blog",
+    "mezzanine.forms",
+    "mezzanine.pages",
+    "mezzanine.galleries",
+    "mezzanine.twitter",
+    "mezzanine.mobile",
 )
 
 


### PR DESCRIPTION
This change will make the instructions README.rst work.
No first-contact-frustration anymore for interested users. :)